### PR TITLE
feat(cors): reflect request origin to allow third party services

### DIFF
--- a/environment/environment.env.dist
+++ b/environment/environment.env.dist
@@ -1,4 +1,3 @@
-ORIGIN=frontendCorsUrl
 MONGO_URL=connectionString
 
 AIRTABLE_URL=airtableUrl

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { ValidationPipe } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
@@ -20,10 +19,8 @@ async function bootstrap() {
     });
     SwaggerModule.setup('api', app, document);
 
-    const configService = app.get(ConfigService);
-
     app.useGlobalPipes(new ValidationPipe());
-    app.enableCors({ origin: configService.get('ORIGIN'), credentials: true });
+    app.enableCors({ origin: true, credentials: true });
     app.use(cookieParser());
 
     await app.listen(process.env.PORT || 3001);


### PR DESCRIPTION
Let the API respond with the same ORIGIN as the request was made. This allows external third party services to use our API.