### PR TITLE
fix(validation): increase description length to 8192

### DIFF
--- a/src/database/schemas/dao-proposal.schema.ts
+++ b/src/database/schemas/dao-proposal.schema.ts
@@ -116,7 +116,7 @@ export class DaoProposal {
     @Prop({
         type: String,
         trim: true,
-        maxLength: 4096,
+        maxLength: 8192,
     })
     @ApiProperty()
     description: string;

--- a/src/database/schemas/project.schema.ts
+++ b/src/database/schemas/project.schema.ts
@@ -43,7 +43,7 @@ export class Project {
     @Prop({
         type: String,
         trim: true,
-        maxLength: 4096,
+        maxLength: 8192,
     })
     @ApiProperty()
     description: string;
@@ -142,5 +142,4 @@ export class Project {
     updatedAt: Date;
 }
 
-export const ProjectSchema =
-    SchemaFactory.createForClass(Project).plugin(PaginatePlugin);
+export const ProjectSchema = SchemaFactory.createForClass(Project).plugin(PaginatePlugin);


### PR DESCRIPTION
We ran into into an exception because a new proposal in Airtable exceeded current description limit of 4096 characters.